### PR TITLE
Dir const indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ or double-click the corresponding icon.
 Alternatively, from the Dyalog interpreter:
 
     2⎕FIX{⍵⌿⍨(' '=⊃¨⍵)∨':{}'∘(∨/∊)¨⍵}⊃⎕NGET'gg.apls'1
-    Sim'gg.json'
+    Sim'gg.json5'
 
 Plotting
 --------

--- a/gg.apls
+++ b/gg.apls
@@ -52,7 +52,7 @@ _GG_←{⎕IO←0                                                          ⍝ G
     (q x)←⍵ ⋄ f←4⍴⊂≠⍨v←q>0                                           ⍝ orientations, total time and fractions
     g←(⍺⍺.G0×⊢×1-⍟)@(0∘<)¨1⌊h÷⍨⍳1+h←⍵⍵.L⍺⍺.hagb                      ⍝ grain boundary energy
     m←(⍺⍺.M0×*-⍺⍺.Qg÷8.314×⍺)×1-*-⍺⍺.A×⍺⍺.n*⍨h÷⍨⍳1+h                 ⍝ grain boundary mobility
-    K←(⌷∘(∘.((÷2)*⍨+⍥(×⍨))⍨⍳3),)¨                                    ⍝ directional constant
+    K←((,0.5*⍨∘.+⍨2*⍨⍳3)⌷⍨∘⊂⊢+3×⊣)                                   ⍝ directional constant    
     _P←{_←⍺⍺ ⍺⎕NPUT⍨⊂↓(t←'-'@('¯'∘=)14 ¯6⍕⍵) ⋄ t}                    ⍝ write to file and return text
     _←1(w2 _P)⍉↑(⍵⍵.D⍳1+h)g m ⋄ (g m)×←d*2 ¯4 ⋄ gh←⊢/g               ⍝ write boundary energies and mobilities
     D←h⌊⍵⍵.M ⋄ N←¯1 1(⊖¨,⌽¨)⊂ ⋄ L←(⍵⍵.L ⍺⍺.lagb)∘>                   ⍝ disorientation, neighbours, low angle


### PR DESCRIPTION
Creating giant nested array for indexing in `K` is costly. Try a flatter approach.
```
      ]runtime -c "((lse+lsw)(,⍤0)1+lns)⌷⍤1 99⊢const" "(lse+lsw)K 1+lns"
                                                                                             
  ((lse+lsw)(,⍤0)1+lns)⌷⍤1 99⊢const → 1.3E¯1 |   0% ⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕                    
  (lse+lsw)K 1+lns                  → 2.4E¯1 | +87% ⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕⎕ 
```
`K←((⌷⍤1 99)∘const(,⍤0))`
`const ← 0.5*⍨∘.+⍨2*⍨⍳3`

We can do even faster scatter indexing into a vector:
```
      const←,0.5*⍨∘.+⍨2*⍨⍳3
      ⍴const[(3×lne+lsw)+1+lwe]   
801 800
```

`⍵+3×⍺` comes from converting index into const matrix into raveled form. `⎕IO←0 ⋄ ⍵+3×⍺ ←→ ,3 3⊥⍉⍺(,⍤0)⍵` 

Original:
![Pasted image 20240116100115](https://github.com/yiyus/gg/assets/9338369/1a42d156-34de-4f06-bab2-b85eb8b49c76)

Vector:
![Pasted image 20240116100914](https://github.com/yiyus/gg/assets/9338369/54855e6c-c484-4392-88a8-80c2e7e6ad82)


